### PR TITLE
Remove java from automatically being installed.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -54,11 +54,13 @@ platforms:
 suites:
   - name: default
     run_list:
+      - recipe[jenkinsstack::java]
       - recipe[jenkinsstack::master]
       - recipe[jenkinsstack::ruby]
       - recipe[jenkinsstack::find_all]
   - name: slave
     run_list:
+      - recipe[jenkinsstack::java]
       - recipe[jenkinsstack::slave]
       - recipe[jenkinsstack::ruby]
       - recipe[jenkinsstack::find_all]

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ Here are attributes exposed by this stack. Please note that you may also overrid
 
 Nothing. This recipe is empty.
 
+### jenkinsstack::java
+
+Calls the jenkins cookbook's java recipe.
+
 ### jenkinsstack::master
 
 Configures a Jenkins master. Configures any slaves found using Chef search (slaves are found based on tags used in jenkinsstack::slave).

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'rackspace-cookbooks@rackspace.com'
 license          'Apache 2.0'
 description      'Installs/Configures jenkinsstack'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.0'
+version          '1.0.0'
 
 depends 'chef-sugar'
 depends 'jenkins', '2.1.2' # see github:racker/jenkins before changing this

--- a/recipes/_base.rb
+++ b/recipes/_base.rb
@@ -36,8 +36,6 @@ node['jenkinsstack']['packages'].each do |pkg|
   end
 end
 
-include_recipe 'jenkins::java'
-
 ## Hate to do these creates here, but we want them to exist before installing
 ## Jenkins as the keys created are used on jenkins setup
 # Create the Jenkins user

--- a/recipes/java.rb
+++ b/recipes/java.rb
@@ -1,0 +1,11 @@
+# Encoding: utf-8
+#
+# Cookbook Name:: jenkinsstack
+# Recipe:: java
+#
+# Copyright 2014, Rackspace
+#
+
+# this recipe may eventually do more, but not right now.
+# wrap the java one.
+include_recipe 'jenkins::java'


### PR DESCRIPTION
Still provides a ::java recipe that passes back to jenkins upstream. Some customers didn't want this java, and this provides away for them to omit it. But, folks who want it must now include it specifically.
