### PR TITLE
Fixes node.run_state parameter keys to be right

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# 1.0.1
+
+Refactor auth to prevent a problem during convergence. Now, the chef user and
+credentials are created but not passed to jenkins::* recipes on the first chef
+run, and at the very end, Jenkins is restarted. The credentials are only passed
+on subsequent runs which require them after the restart.
+
+# 1.0.0
+
+Java behavior has been extracted into its own recipe. Call the java recipe here
+to use a wrapper from jenkins::java. Otherwise, you must ensure java is installed
+before using the master or slave recipes in this cookbook.
+
+
 # 0.1.0
 
 Initial release of jenkinsstack

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'rackspace-cookbooks@rackspace.com'
 license          'Apache 2.0'
 description      'Installs/Configures jenkinsstack'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.0.0'
+version          '1.0.1'
 
 depends 'chef-sugar'
 depends 'jenkins', '2.1.2' # see github:racker/jenkins before changing this

--- a/recipes/_base.rb
+++ b/recipes/_base.rb
@@ -35,24 +35,3 @@ node['jenkinsstack']['packages'].each do |pkg|
     action :install
   end
 end
-
-## Hate to do these creates here, but we want them to exist before installing
-## Jenkins as the keys created are used on jenkins setup
-# Create the Jenkins user
-user node['jenkins']['master']['user'] do
-  home node['jenkins']['master']['home']
-  shell '/bin/bash'
-end
-
-# Create the Jenkins group
-group node['jenkins']['master']['group'] do
-  members node['jenkins']['master']['user']
-end
-
-# create .ssh dir for jenkins
-directory "#{node['jenkins']['master']['home']}/.ssh" do
-  owner node['jenkins']['master']['user']
-  group node['jenkins']['master']['group']
-  mode 00700
-  recursive true
-end

--- a/recipes/_base.rb
+++ b/recipes/_base.rb
@@ -26,12 +26,34 @@ node.default['jenkins']['master']['listen_address'] = '127.0.0.1'
 # http://mirrors.jenkins-ci.org/war/ and the second is the sha256 hash of the file to prevent download
 # of the war file on every Chef run.
 # comment out old version --
-# node.default['jenkins']['master']['version']      = '1.571'
-# node.default['jenkins']['master']['checksum'] = '312d0a3fa6a394e2c9e6d31042b7db70674eb3abb3a431a41390fef97db0f9f4'
+node.default['jenkins']['master']['version']      = '1.555'
+node.default['jenkins']['master']['checksum'] = '31f5c2a3f7e843f7051253d640f07f7c24df5e9ec271de21e92dac0d7ca19431'
 node.default['jenkins']['master']['install_method'] = 'war'
 
 node['jenkinsstack']['packages'].each do |pkg|
   package pkg do
     action :install
   end
+end
+
+# Hate to do these creates here, since they are also on _prep_keys, but slaves
+# need them too.
+
+# Create the Jenkins user
+user node['jenkins']['master']['user'] do
+  home node['jenkins']['master']['home']
+  shell '/bin/bash'
+end
+
+# Create the Jenkins group
+group node['jenkins']['master']['group'] do
+  members node['jenkins']['master']['user']
+end
+
+# create .ssh dir for jenkins
+directory "#{node['jenkins']['master']['home']}/.ssh" do
+  owner node['jenkins']['master']['user']
+  group node['jenkins']['master']['group']
+  mode 00700
+  recursive true
 end

--- a/recipes/_prep_keys.rb
+++ b/recipes/_prep_keys.rb
@@ -61,6 +61,8 @@ prepare_keys = ruby_block 'prepare_keys' do # ~FC014
 
       node.set['jenkinsstack']['jenkins_slave_ssh_pubkey'] = s_public_key
       node.save unless Chef::Config['solo']
+
+      # needed every run for creating credentials object in jenkins
       node.run_state['jenkinsstack_private_key'] = s_private_key
 
       # first time when no file exists, just create them from templates
@@ -88,9 +90,13 @@ prepare_keys = ruby_block 'prepare_keys' do # ~FC014
       key = OpenSSL::PKey::RSA.new(File.read(pkey))
       s_private_key = key.to_pem
 
+      # needed every run for creating credentials object in jenkins
+      node.run_state['jenkinsstack_private_key'] = s_private_key
+
       # only populate if they already existed (else first run breaks)
       node.run_state[:jenkins_private_key_path] = pkey
       node.run_state[:jenkins_private_key] = s_private_key
+
     end # end file exists
   end
   action :nothing

--- a/recipes/_prep_keys.rb
+++ b/recipes/_prep_keys.rb
@@ -23,59 +23,90 @@ require 'sshkey'
 # Base location of ssh key
 pkey = node['jenkins']['master']['home'] + '/.ssh/id_rsa'
 
-# if the keys don't exist, create them using templates, and set variables
-if !File.exist?(pkey)
-  # Generate a keypair with Ruby
-  sshkey = SSHKey.generate(
-    type: 'RSA',
-    comment: "#{node['jenkins']['master']['user']}@#{node['jenkins']['master']['host']}"
-  )
-
-  # Store private key on disk
-  template pkey do
-    owner node['jenkins']['master']['user']
-    group node['jenkins']['master']['group']
-    source 'id_rsa.erb'
-    variables(
-      ssh_private_key: sshkey.private_key
-    )
-    mode 00600
-    action :create_if_missing
-  end
-
-  # Store public key on disk
-  template "#{pkey}.pub" do
-    owner node['jenkins']['master']['user']
-    group node['jenkins']['master']['group']
-    source 'id_rsa.pub.erb'
-    variables(
-      ssh_public_key: sshkey.ssh_public_key
-    )
-    mode 00644
-    action :create_if_missing
-  end
-
-  s_private_key = sshkey.private_key.to_s
-  s_public_key  = sshkey.ssh_public_key.to_s
-
-else # otherwise just set variables from existing key
-
-  key = OpenSSL::PKey::RSA.new(File.read(pkey))
-  s_private_key = key.to_pem
-  s_public_key  = "#{key.ssh_type} #{[key.to_blob].pack('m0')}"
-
-end
-
-# Save public key to chef-server as jenkins_slave_ssh_pubkey
-ruby_block 'node-save-pubkey' do
+# this should happen at compile time, or the upstream jenkins cookbook's ruby
+# code will fail to find these keys we setup
+prepare_keys = ruby_block 'prepare_keys' do
   block do
-    node.set['jenkinsstack']['jenkins_slave_ssh_pubkey'] = s_public_key
-    node.save unless Chef::Config['solo']
+
+    # Create the Jenkins user
+    u = Chef::Resource::User.new(node['jenkins']['master']['user'], run_context)
+    u.home node['jenkins']['master']['home']
+    u.shell '/bin/bash'
+    u.run_action :create
+
+    # Create the Jenkins group
+    g = Chef::Resource::Group.new(node['jenkins']['master']['group'], run_context)
+    g.members node['jenkins']['master']['user']
+    g.run_action :create
+
+    # create .ssh dir for jenkins
+    d = Chef::Resource::Directory.new("#{node['jenkins']['master']['home']}/.ssh", run_context)
+    d.owner node['jenkins']['master']['user']
+    d.group node['jenkins']['master']['group']
+    d.mode 00700
+    d.recursive true
+    d.run_action :create
+
+    if !File.exist?(pkey)
+      # Generate a keypair with Ruby
+      sshkey = SSHKey.generate(
+        type: 'RSA',
+        comment: "#{node['jenkins']['master']['user']}@#{node['jenkins']['master']['host']}"
+      )
+
+      r = Chef::Resource::Template.new(pkey, run_context)
+      r.path pkey
+      r.owner node['jenkins']['master']['user']
+      r.group node['jenkins']['master']['group']
+      r.cookbook 'jenkinsstack'
+      r.source 'id_rsa.erb'
+      r.variables  ssh_private_key: sshkey.private_key
+      r.mode 00600
+      r.run_action :create
+
+      s = Chef::Resource::Template.new("#{pkey}.pub", run_context)
+      s.path "#{pkey}.pub"
+      s.owner node['jenkins']['master']['user']
+      s.group node['jenkins']['master']['group']
+      s.cookbook 'jenkinsstack'
+      s.source 'id_rsa.pub.erb'
+      s.variables ssh_public_key: sshkey.ssh_public_key
+      s.mode 00644
+      s.run_action :create
+
+      s_private_key = sshkey.private_key.to_s
+      s_public_key  = sshkey.ssh_public_key.to_s
+
+      node.set['jenkinsstack']['jenkins_slave_ssh_pubkey'] = s_public_key
+      node.save unless Chef::Config['solo']
+
+      node.run_state['jenkinsstack_private_key'] = s_private_key
+      node.run_state[:jenkins_private_key_path] = pkey
+      node.run_state[:jenkins_private_key] = s_private_key
+    end # end file exists
+
+    # just set variables from existing keys
+    key = OpenSSL::PKey::RSA.new(File.read(pkey))
+    s_private_key = key.to_pem
+    s_public_key  = "#{key.ssh_type} #{[key.to_blob].pack('m0')}"
+
+    node.run_state['jenkinsstack_private_key'] = s_private_key
+    node.run_state[:jenkins_private_key_path] = pkey
+    node.run_state[:jenkins_private_key] = s_private_key
+    x = s_private_key
+    Chef::Log.warn("Setting run state now in _prep_keys")
   end
+  action :nothing
 end
 
-# Set the private key on the Jenkins executor in ruby, and at compile time.
+# now, do it now!
+prepare_keys.run_action(:run)
+
+# gather these one more time for the cookbook convergence
+key = OpenSSL::PKey::RSA.new(File.read(pkey))
+s_private_key = key.to_pem
+s_public_key  = "#{key.ssh_type} #{[key.to_blob].pack('m0')}"
+
 node.run_state['jenkinsstack_private_key'] = s_private_key
-ruby_block 'set private key' do
-  block { node.run_state['jenkinsstack_private_key'] = s_private_key }
-end
+node.run_state[:jenkins_private_key_path] = pkey
+node.run_state[:jenkins_private_key] = s_private_key

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -28,19 +28,19 @@ user node['jenkins']['master']['user'] do
   action :manage
 end
 
+# Create jenkins auth user, this enables auth for further actions
+jenkins_user 'chef' do
+  public_keys [s_public_key]
+end
+
 # install plugins and theme
 include_recipe 'jenkinsstack::_plugins'
 
-# create jenkins credential
+# create jenkins credential, useful to ssh to slaves
 jenkins_private_key_credentials node['jenkins']['master']['user'] do
   username node['jenkins']['master']['user']
   description 'Jenkins Slave SSH Key'
   private_key s_private_key
-end
-
-# Create jenkins auth user
-jenkins_user 'chef' do
-  public_keys [s_public_key]
 end
 
 # find any existing slaves

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -13,7 +13,7 @@ include_recipe 'chef-sugar'
 include_recipe 'jenkinsstack::_base'
 
 # prepare keys for master and slaves, set handy variables
-include_recipe 'jenkinsstack::_prep_keys'
+include_recipe('jenkinsstack::_prep_keys')
 s_private_key = node.run_state['jenkinsstack_private_key']
 s_public_key  = node['jenkinsstack']['jenkins_slave_ssh_pubkey']
 

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -12,21 +12,16 @@ include_recipe 'chef-sugar'
 # Run base recipe (apt, java, various settings)
 include_recipe 'jenkinsstack::_base'
 
-# prepare keys for master and slaves, set handy variables
-include_recipe('jenkinsstack::_prep_keys')
-s_private_key = node.run_state['jenkinsstack_private_key']
-s_public_key  = node['jenkinsstack']['jenkins_slave_ssh_pubkey']
-
 # Pin to 1.555 until JENKINS-22346 is fixed
 # https://issues.jenkins-ci.org/browse/JENKINS-22346
 node.override['jenkins']['master']['version'] = '1.555'
 node.override['jenkins']['master']['runit']['sv_timeout'] = 45
 include_recipe 'jenkins::master'
 
-user node['jenkins']['master']['user'] do
-  shell '/bin/bash'
-  action :manage
-end
+# prepare keys for master and slaves, set handy variables
+include_recipe 'jenkinsstack::_prep_keys'
+s_private_key = node.run_state['jenkinsstack_private_key']
+s_public_key  = node['jenkinsstack']['jenkins_slave_ssh_pubkey']
 
 # Create jenkins auth user, this enables auth for further actions
 jenkins_user 'chef' do


### PR DESCRIPTION
Fixes https://github.com/AutomationSupport/jenkinsstack/issues/19.

Apparently node.run_state[:foo] != node.run_state['foo']. Had to change some node.run_state keys to make upstream have the appropriate settings.
