### PR TITLE
Added read of pub keys, rubocop fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,3 +37,8 @@ WordArray:
 # Don't complain about unused block args
 UnusedBlockArgument:
   Enabled: false
+
+# Don't complain about Guardfile
+AllCops:
+  Exclude:
+    - 'Guardfile'

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 group :lint do
   gem 'foodcritic', '~> 3.0'
-  gem 'foodcritic-rackspace-rules', :git => 'git@github.com:AutomationSupport/foodcritic-rackspace-rules.git'
+  gem 'foodcritic-rackspace-rules', git: 'git@github.com:AutomationSupport/foodcritic-rackspace-rules.git'
   gem 'rubocop', '~> 0.24'
 end
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Stack used to configure a jenkins master and any number of jenkins slaves. By default, the stack uses SSH slaves (master initiated) as opposed to JNLP slaves (slave initiated). The master generates a private key that is used for jenkins authentication as well as passwordless SSH from master to slaves.
 
+## Disclaimers
+
+Changing of Jenkins SSH key pairs should be considered unsupported.  If a specific SSH key is desired, please add this before the initial buildout.  It is possible to manually change this, but it does require manual changes on the server.
+
 ## [Changelog](CHANGELOG.md)
 
 See CHANGELOG.md for additional information about changes to this stack over time.

--- a/Thorfile
+++ b/Thorfile
@@ -8,5 +8,5 @@ begin
   require 'kitchen/thor_tasks'
   Kitchen::ThorTasks.new
 rescue LoadError
-  puts ">>>>> Kitchen gem not loaded, omitting tasks" unless ENV['CI']
+  puts '>>>>> Kitchen gem not loaded, omitting tasks' unless ENV['CI']
 end

--- a/recipes/_base.rb
+++ b/recipes/_base.rb
@@ -31,7 +31,6 @@ node.default['jenkins']['master']['version']      = '1.555'
 node.default['jenkins']['master']['checksum'] = '31f5c2a3f7e843f7051253d640f07f7c24df5e9ec271de21e92dac0d7ca19431'
 node.default['jenkins']['master']['source'] = "#{node['jenkins']['master']['mirror']}/war/#{node['jenkins']['master']['version']}/jenkins.war"
 
-
 node['jenkinsstack']['packages'].each do |pkg|
   package pkg do
     action :install

--- a/recipes/_base.rb
+++ b/recipes/_base.rb
@@ -9,7 +9,6 @@
 node.override['apt']['compile_time_update'] = true
 include_recipe 'apt'
 
-node.override['build-essential']['compile_time'] = true
 include_recipe 'build-essential'
 
 # get curl for testing/jenkins stuff

--- a/recipes/_prep_keys.rb
+++ b/recipes/_prep_keys.rb
@@ -55,6 +55,11 @@ prepare_keys = ruby_block 'prepare_keys' do # ~FC014
       # needed every run for creating credentials object in jenkins
       node.run_state['jenkinsstack_private_key'] = s_private_key
 
+      # update pub key as well
+      s_public_key  = "#{key.ssh_type} #{[key.to_blob].pack('m0')}"
+      node.set['jenkinsstack']['jenkins_slave_ssh_pubkey'] = s_public_key
+      node.save unless Chef::Config['solo']
+
       # only populate if they already existed (else first run breaks)
       node.run_state[:jenkins_private_key_path] = pkey
       node.run_state[:jenkins_private_key] = s_private_key


### PR DESCRIPTION
https://github.com/rackspace-cookbooks/jenkinsstack/issues/23

Put in a note about on the fly changing of SSH keys for jenkins being unsupported.
